### PR TITLE
Fix the wrong recruiting url in the API docs

### DIFF
--- a/personio-recruiting-api.yaml
+++ b/personio-recruiting-api.yaml
@@ -174,7 +174,7 @@ paths:
 
 
 servers:
-  - url: https://api.personio.de/v1
+  - url: https://api.personio.de
 components:
   securitySchemes:
     BearerAuth:


### PR DESCRIPTION
## Context

Currently the docs for personio API are wrong in the developers website. There is a `v1` in the URL that does not exist in the code. 

Also in other part of the docs we have the URL without the V1 (https://developer.personio.de/docs/applications-endpoint)

## Solution
- To do not break our customers changing the URL we just updated the wrong part of the docs