### PR TITLE
[RCO-190] Fix documents description

### DIFF
--- a/personio-recruiting-api.yaml
+++ b/personio-recruiting-api.yaml
@@ -339,28 +339,28 @@ components:
           description: Date from which this applicant is available from
           type: string
           maxLength: 100
-        categorised_documents:
-          description: Array of files and category names. <br/>
-            Each file in the array should be an upload stream. <br/>
-            Each category in the array should be a category name. <br/>
+        categorised_documents[n][file]:
+          description: Nth file <br/>
+            The file should be an upload stream. <br/>
             You can check a request example in the "A note on categorised documents" section. <br/>
             [array of files] <br/>
             allowed extensions are 'pdf', 'docx', 'doc', 'jpg', 'png', 'txt', 'jpeg', 'odt', 'ods','xlsx', 'rtf', 'xls', 'pptx', 'ppt', 'gif', 'tif', 'tiff', 'bmp', 'csv', 'rar', 'gz', 'zip', '7z'; <br/>
             filesize per document < 20M; <br/>
             total post size < 64M; <br/>
-            [array of category names] <br/>
+          type: string
+          format: binary
+        categorised_documents[n][category]:
+          description: Nth file's category <br/>
+            Category of the Nth file. <br/>
+            You can check a request example in the "A note on categorised documents" section. <br/>
             allowed values are 'cv', 'cover-letter', 'employment-reference', 'certificate', 'work-sample' or 'other' <br/>
-          type: array
-          items:
-            $ref: "#/components/schemas/CategorizedDocument"
+          type: string
         documents:
           description: Array of documents that are attached to this application. <br/>
             [array of files] <br/>
             allowed extensions are 'pdf', 'docx', 'doc', 'jpg', 'png', 'txt', 'jpeg', 'odt', 'ods','xlsx', 'rtf', 'xls', 'pptx', 'ppt', 'gif', 'tif', 'tiff', 'bmp', 'csv', 'rar', 'gz', 'zip', '7z'; <br/>
             filesize per document < 20M; <br/>
             total post size < 64M; <br/>
-            [array of category names] <br/>
-            allowed values are 'cv', 'cover-letter', 'employment-reference', 'certificate', 'work-sample' or 'other' <br/>
           type: array
           items:
             $ref: "#/components/schemas/Document"
@@ -396,21 +396,6 @@ components:
         - first_name
         - last_name
         - email
-
-    CategorizedDocument:
-      title: Categorized document
-      type: object
-      properties:
-        file:
-          type: string
-          format: binary
-          description: "allowed extensions are 'pdf', 'docx', 'doc', 'jpg', 'png', 'txt', 'jpeg', 'odt', 'ods','xlsx', 'rtf', 'xls', 'pptx', 'ppt', 'gif', 'tif', 'tiff', 'bmp', 'csv', 'rar', 'gz', 'zip', '7z'
-            filesize per document < 20M
-            total post size < 64M"
-        category:
-          type: string
-          enum: ['cv', 'cover-letter', 'employment-reference', 'certificate', 'work-sample', 'other']
-          description: allowed values are 'cv', 'cover-letter', 'employment-reference', 'certificate', 'work-sample' or 'other'
 
     Document:
       title: Document

--- a/personio-recruiting-api.yaml
+++ b/personio-recruiting-api.yaml
@@ -340,7 +340,7 @@ components:
           type: string
           maxLength: 100
         categorised_documents[n][file]:
-          description: Nth file <br/>
+          description: Nth document <br/>
             The file should be an upload stream. <br/>
             You can check a request example in the "A note on categorised documents" section. <br/>
             [array of files] <br/>
@@ -350,20 +350,19 @@ components:
           type: string
           format: binary
         categorised_documents[n][category]:
-          description: Nth file's category <br/>
+          description: Nth document's category <br/>
             Category of the Nth file. <br/>
             You can check a request example in the "A note on categorised documents" section. <br/>
             allowed values are 'cv', 'cover-letter', 'employment-reference', 'certificate', 'work-sample' or 'other' <br/>
           type: string
-        documents:
-          description: Array of documents that are attached to this application. <br/>
-            [array of files] <br/>
+        documents[n]:
+          description: Nth document <br/>
+            The file should be an upload stream. <br/>
             allowed extensions are 'pdf', 'docx', 'doc', 'jpg', 'png', 'txt', 'jpeg', 'odt', 'ods','xlsx', 'rtf', 'xls', 'pptx', 'ppt', 'gif', 'tif', 'tiff', 'bmp', 'csv', 'rar', 'gz', 'zip', '7z'; <br/>
             filesize per document < 20M; <br/>
             total post size < 64M; <br/>
-          type: array
-          items:
-            $ref: "#/components/schemas/Document"
+          type: string
+          format: binary
         document{n}:
           description: Alternatively to an array (see 'documents'), documents can also be transferred individually numbered document1, document2, etc (the numbering starts at 1) with the absolute path to the document in an upload stream. <br/>
             [file] <br/>


### PR DESCRIPTION
The current OpenAPI file is using `categorised_documents` and `documents` as array fields in the multipart form-data which is incorrect. 

**Previously:**
`
"categorised_documents": [
    "file": File,
    "category": "cv",
],
"documents": [
    File
]
`

**With the new changes:**
`
"categorised_documents[0][file]": File,
"categorised_documents[0][category]": File,
"documents[0]": File
`