### PR TITLE
[TT-1841] Update attendance get endpoint docs to include rejected status

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -842,7 +842,7 @@ paths:
         - name: includePending
           in: query
           required: false
-          description: Returns AttendancePeriods with a status of pending as well as confirmed. In this case, the end_date attribute is nullable. The status of each period is included in the response.
+          description: Returns AttendancePeriods with a status of pending, rejected and confirmed. For pending periods, the end_date attribute is nullable. The status of each period is included in the response.
           schema:
             type: boolean
         - name: employees[]
@@ -910,7 +910,7 @@ paths:
                           start_time: '09:30'
                           end_time: '18:30'
                           updated_at: '2017-01-18T16:41:08+01:00'
-                          status: ['confirmed', 'pending']
+                          status: 'pending'
                           break: 60
                           comment: I wasn't productive
                           is_holiday: false
@@ -2193,6 +2193,12 @@ components:
         is_on_time_off:
           type: boolean
           example: false
+        status: 
+          type: string
+          enum: 
+            - confirmed
+            - pending
+            - rejected
 
     AttendanceCreateRequest:
       type: object


### PR DESCRIPTION
# Description

Updates the documentation around the `includePending` flag on the Attendances `get` endpoint. We'll include periods with the `rejected` status from now on. 