### PR TITLE
Rephrase default attendance comment bad language

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -899,7 +899,7 @@ paths:
                           updated_at: '2017-01-17T16:41:08+00:00'
                           status: 'confirmed'
                           break: 50
-                          comment: I was productive as hell
+                          comment: I was super productive
                           is_holiday: false
                           is_on_time_off: false
                       - id: 1235


### PR DESCRIPTION
This PR changes the default comment in the attendance endpoint.

"hell" is considered profanity because it is (or was) frequently used as a curse and it is (or was) considered blasphemous.
