### PR TITLE
Absences: offset parameter does not match documentation

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -1388,19 +1388,20 @@ paths:
         - name: limit
           in: query
           required: false
-          description: Pagination attribute to limit how many attendances is returning per page
+          description: Pagination attribute to limit how many absences to return per page. Maximum is 200.
           schema:
             type: integer
             minimum: 1
+            maximum: 200
             default: 200
         - name: offset
           in: query
           required: false
-          description: Pagination attribute to identify which page you are requesting, by the form of telling an offset from the first record that would be returned.
+          description: Pagination attribute to identify which page to request from the chunks indicated by `limit`. The value `0` is interpreted as page `1`. You cannot pass a value larger than the available amount of pages, as returned by the `total_pages` meta data in the response.
           schema:
             type: integer
-            minimum: 0
-            default: 0
+            minimum: 1
+            default: 1
       responses:
         "200":
           description: ""


### PR DESCRIPTION
Problem
- The `GET /company/time-offs` parameter `offset` is documented as zero based and the wording "telling an offset from the first record that would be returned" suggests that it accepts an offset of records instead of pages.

https://github.com/personio/api-docs/blob/7ab761e3095d2321ce7afed1bd0cd557d68210df/personio-personnel-data-api-oa3.yaml#L1396-L1403

Actual behavior

- The `offset` parameter is based on `1`. Passing `0` is automatically converted into `1` in the API. This results in duplicate response data when the client is counting up `$offset++`, as the client is first passing `0` then `1`.

- The `offset` parameter indicates the "page" to retrieve, chunked by `limit`.
