### PR TITLE
Fix #101: add missing attribute for department, make required

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -2489,8 +2489,15 @@ components:
               example: Department
             attributes:
               type: object
+              required:
+                - id
+                - name
               properties:
+                id:
+                  type: integer
+                  example: 1
                 name:
+                  type: string
                   example: Marketing
         type:
           $ref: '#/components/schemas/TypeEnum'


### PR DESCRIPTION
This PR adds the missing `id` field to the attributes of `Department` and makes both `id` and `name` required to enable better typing in generated code. Since Departments are only returned by the API this shouldn't break any dependent code.

Closes #101 