### PR TITLE
Fix types and required fields

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -3507,15 +3507,21 @@ components:
           type: string
     ShortEmployee:
       type: object
+      required:
+        - attributes
       properties:
         type:
           type: string
           example: Employee
         attributes:
           type: object
+          required:
+            - id
           properties:
             id:
               type: object
+              required:
+                - value
               properties:
                 label:
                   example: 1

--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -2607,8 +2607,14 @@ components:
               example: Team
             attributes:
               type: object
+              required:
+                - id
               properties:
+                id:
+                  type: number
+                  example: 1
                 name:
+                  type: string
                   example: Management
         type:
           $ref: '#/components/schemas/TypeEnum'

--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -2659,9 +2659,13 @@ components:
 
     Employee:
       type: object
+      required:
+        - id
       properties:
         id:
           type: object
+          required:
+            - value
           properties:
             label:
               example: ID

--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -3503,6 +3503,8 @@ components:
         updated_at:
           type: string
           example: 2017-01-17T10:32:18+0100
+        comment:
+          type: string
     ShortEmployee:
       type: object
       properties:

--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -3449,6 +3449,17 @@ components:
 
     Absence:
       type: object
+      required:
+        - id
+        - status
+        - start_date
+        - end_date
+        - half_day_start
+        - half_day_end
+        - time_off_type
+        - employee
+        - created_at
+        - updated_at
       properties:
         id:
           type: integer
@@ -3479,6 +3490,8 @@ components:
               example: TimeOffType
             attributes:
               type: object
+              required:
+                - id
               properties:
                 id:
                   type: integer

--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -2138,7 +2138,7 @@ components:
             data:
               type: object
               properties:
-                id: 
+                id:
                   type: integer
                   example: 1
                 type:
@@ -2993,12 +2993,12 @@ components:
             data:
               type: array
               items:
-                type: object
-                properties:
-                  type:
-                    example: Employee
-                  attributes:
-                    $ref: "#/components/schemas/Employee"
+            type: object
+            properties:
+              type:
+                example: Employee
+              attributes:
+                $ref: "#/components/schemas/Employee"
 
     EmployeeAbsenceBalance:
       title: Employee Absence Balance
@@ -3117,14 +3117,14 @@ components:
               type: string
               example: "Project"
             attributes:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    example: "A project name"
-                  active:
-                    type: boolean
-                    example: true
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: "A project name"
+                active:
+                  type: boolean
+                  example: true
 
     AttendanceCreateRequest:
       type: object
@@ -3292,13 +3292,13 @@ components:
             data:
               type: object
               properties:
-                id:
-                  type: array
-                  items:
-                    type: integer
-                    example: 1
-                message:
-                  example: Success
+            id:
+              type: array
+              items:
+                type: integer
+                example: 1
+            message:
+              example: Success
 
     TimeOffTypeResource:
       title: Type of time-off resource
@@ -3311,6 +3311,8 @@ components:
           description: Time-off type resource name
         attributes:
           type: object
+          required:
+            - id
           properties:
             id:
               type: integer

--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -2480,6 +2480,7 @@ components:
       type: object
       properties:
         label:
+          type: string
           example: Department
         value:
           type: object
@@ -2495,6 +2496,7 @@ components:
         type:
           $ref: '#/components/schemas/TypeEnum'
         universal_id:
+          type: string
           example: department
     CostCenters:
       type: object


### PR DESCRIPTION
This PR adds:

* Missing types in Department (`label` and `universal_id`)
* Missing id poperty in Team (`id`) and type (`name` is a string)
* Missing property in Absence (`comment`, string)
* Required properties in ShortEmployee (`attributes.id.value`)
* Required properties in Absence (many, all part of responses)
* Required properties in Employee (`id.value`)
* Required property in Time-off type (`id`)

Every change is isolated in its own commit so it should be easy to revert them, should they not be desired. I believe none of the changes should break client code since they either add fields that are part of the responses, fix types, or specify that a response will always contain them.
