### PR TITLE
[CAT-4656] Use individual server spec for each Recruiting endpoint

### DIFF
--- a/personio-recruiting-api.yaml
+++ b/personio-recruiting-api.yaml
@@ -44,6 +44,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/XmlResponse'
   /v1/recruiting/applications:
+    servers:
+      - url: 'https://api.personio.de'
     parameters:
       - $ref: "#/components/parameters/XPersonioPartnerID"
       - $ref: "#/components/parameters/XPersonioAppID"
@@ -86,6 +88,8 @@ paths:
             schema:
               $ref: '#/components/schemas/submit_application'
   /v1/recruiting/applications/documents:
+    servers:
+      - url: 'https://api.personio.de'
     parameters:
       - $ref: "#/components/parameters/XPersonioPartnerID"
       - $ref: "#/components/parameters/XPersonioAppID"
@@ -172,6 +176,8 @@ paths:
               required:
                 - file
   /recruiting/applicant:
+    servers:
+      - url: 'https://api.personio.de'
     parameters:
       - $ref: "#/components/parameters/XPersonioPartnerID"
       - $ref: "#/components/parameters/XPersonioAppID"
@@ -284,8 +290,6 @@ paths:
                     error:
                       message: Service Unavailable
       deprecated: true
-servers:
-  - url: 'https://api.personio.de'
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
Apparently our documentation system doesn’t support `server` override at the endpoint level. For the Recruiting endpoints, one solution would be  to move the `server` spec from the global configuration level to the endpoint level.