### PR TITLE
[PAPI-568] PATCH Employee: Make first_name and last_name parameters not required

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -527,8 +527,6 @@ paths:
                           example: "German"
                   required:
                     - email
-                    - first_name
-                    - last_name
           application/x-www-form-urlencoded:
             schema:
               type: object


### PR DESCRIPTION
This MR removes the required parameter from the attributes `first_name` and `last_name` in the PATCH employees endpoint