### PR TITLE
#148  Update personio-personnel-data-api-oa3.yaml

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -1544,7 +1544,7 @@ paths:
         - BearerAuth: []
       tags:
         - Absences
-      description: Provides a list of absence types for absences **tracked in days**. For example 'Paid vacation', 'Parental leave' or 'Home office'.
+      description: Provides a list of absence types for absences **tracked in days and hours**. For example 'Paid vacation', 'Parental leave' or 'Home office'.
       parameters:
         - name: limit
           in: query


### PR DESCRIPTION
closes #148 

Update endpoint's description:

| before | after |
| ------ | ------ |
|   Provides a list of absence types for absences **tracked in days**. For example 'Paid vacation', 'Parental leave' or 'Home office'.|Provides a list of absence types for absences **tracked in days and hours**. For example 'Paid vacation', 'Parental leave' or 'Home office'.|
