### PR TITLE
Change CustomAttributeValue to oneOf

### DIFF
--- a/common-components-v2.json
+++ b/common-components-v2.json
@@ -179,7 +179,7 @@
         }
       },
       "CustomAttributeValue": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "string",
             "description": "An arbitrary value that can be represented as a string."


### PR DESCRIPTION
Why?
The CustomAttributeValue in the common components is expected to be one of [string, list of strings, list of objects].