### PR TITLE
Update personio-personnel-data-api-oa3.yaml

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -4547,11 +4547,11 @@ components:
           type: number
           example: 3
         half_day_start:
-          type: boolean
-          example: false
+          type: number
+          example: 0
         half_day_end:
-          type: boolean
-          example: false
+          type: number
+          example: 0
         time_off_type:
           type: object
           properties:


### PR DESCRIPTION
The HTTP response returns numbers instead of booleans in case of `GET /company/time-offs`, example:

```yaml
    attributes:
      id: ...
      status: approved
      comment: (...)
      start_date: "2024-01-22T00:00:00+01:00"
      end_date: "2024-01-22T00:00:00+01:00"
      days_count: 1
      half_day_start: 0
      half_day_end: 0
      time_off_type:
        type: TimeOffType
```