### PR TITLE
Add missing employee limit

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -29,6 +29,7 @@ paths:
           schema:
             type: integer
             minimum: 1
+            maximum: 200
             default: 10
             example: 10
         - name: offset


### PR DESCRIPTION
```
curl --request GET \
     --url 'https://api.personio.de/v1/company/employees?limit=201&offset=0' \
     --header 'accept: application/json'
```

returns "The limit must be between 1 and 200."

The minimum is already documented, the maximum is not.

