### PR TITLE
[PAPI-DEV] Add meta to the error object in error response

### DIFF
--- a/common-components-v2.json
+++ b/common-components-v2.json
@@ -134,6 +134,12 @@
                   "format": "uri",
                   "example": "https://developer.personio.de/reference/errors#common.requested_resource_not_found",
                   "description": "A link to the developer hub where more information can be found for the encountered error."
+                },
+                "meta": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
                 }
               }
             }


### PR DESCRIPTION
Add missing meta property to the error response. The property is of type map of string to string to contain contextual information.