### PR TITLE
Changed wording to make the different absence endpoint's time unit clearer

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -1712,7 +1712,7 @@ paths:
         - BearerAuth: []
       tags:
         - Absences
-      description: Provides a list of absence types for absences **tracked in days and hours**. For example 'Paid vacation', 'Parental leave' or 'Home office'.
+      description: Provides a list of absence types for absences **time unit** set to either **days** or **hours**. For example 'Paid vacation', 'Parental leave' or 'Home office'.
       parameters:
         - name: limit
           in: query
@@ -1783,7 +1783,7 @@ paths:
         - BearerAuth: []
       tags:
         - Absences
-      description: Fetches absence periods for absences **tracked in days**. The result can be `paginated` and `filtered` by period and/or specific employee/employees. The result contains a list of absence periods.
+      description: Fetches absence periods for absences with **time unit** set to **days**. The result can be `paginated` and `filtered` by period and/or specific employee/employees. The result contains a list of absence periods.
       parameters:
         - name: start_date
           in: query
@@ -1904,7 +1904,7 @@ paths:
         - BearerAuth: []
       tags:
         - Absences
-      description: Adds absence data for absence types **tracked in days**.
+      description: Adds absence data for absence types with **time unit** set to **days**.
       requestBody:
         content:
           application/x-www-form-urlencoded:
@@ -2028,7 +2028,7 @@ paths:
         - BearerAuth: []
       tags:
         - Absences
-      description: Deletes absence period data for absence types **tracked in days**.
+      description: Deletes absence period data for absence types with **time unit** set to **days**.
       parameters:
         - name: id
           in: path
@@ -2081,7 +2081,7 @@ paths:
         - BearerAuth: []
       tags:
         - Absences
-      description: Gets an absence period for absences **tracked in days**.
+      description: Gets an absence period for absences with **time unit** set to **days**.
       parameters:
         - name: id
           in: path
@@ -2167,7 +2167,7 @@ paths:
         - BearerAuth: [ ]
       tags:
         - Absences
-      description: Fetches absence periods for absences **tracked in hours**. The result can be `paginated` and `filtered` by period and/or specific employee/employees. The result contains a list of hourly absence periods.
+      description: Fetches absence periods for absences with **time unit** set to **hours**. The result can be `paginated` and `filtered` by period and/or specific employee/employees. The result contains a list of hourly absence periods.
       parameters:
         - name: start_date
           in: query
@@ -2330,7 +2330,7 @@ paths:
         - BearerAuth: [ ]
       tags:
         - Absences
-      description: Adds absence data for absence types **tracked in hours**. Note that creating periods for absence types with certificate requirement enabled is not supported!
+      description: Adds absence data for absence types with **time unit** set to **hours**. Note that creating periods for absence types with certificate requirement enabled is not supported!
       requestBody:
         content:
           application/x-www-form-urlencoded:
@@ -2477,7 +2477,7 @@ paths:
         - BearerAuth: []
       tags:
         - Absences
-      description: Deletes absence period data for absence types **tracked in hours**.
+      description: Deletes absence period data for absence types with **time unit** set to **hours**.
       parameters:
         - name: id
           in: path
@@ -4315,7 +4315,7 @@ components:
         - half_day_start
         - half_day_end
     CreateAbsencePeriodRequest:
-      title: Create Absence periods **tracked in hours**
+      title: Create Absence periods with **time unit** set to **hours**
       type: object
       properties:
         employee_id:


### PR DESCRIPTION
Edit made after a customer reached out about this