### PR TITLE
Update personio-personnel-data-api-oa3.yaml update TimeOffType.category enum values

### DIFF
--- a/personio-personnel-data-api-oa3.yaml
+++ b/personio-personnel-data-api-oa3.yaml
@@ -4246,12 +4246,11 @@ components:
                 - child_care
                 - short_time_allowance
                 - quarantine
-                - lockout
                 - irrevocable_exemption
                 - sick_leave
-                - voluntary_military_service
-                - unlawful_strike
-                - lawful_strike
+                - strike_and_lockout
+                - public_duty
+                - unpaid_suspension
                 - paid_vacation
                 - unpaid_vacation
                 - unexcused_absence


### PR DESCRIPTION
Update TimeOffType.category enum values:
- Remove no longer existing category.
- Add the newly introduced categories.

This PR should be merged on 27.01.2025